### PR TITLE
ignore .DS_Store in copy plugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,7 +66,7 @@ const config = {
   plugins: [
     new CleanWebpackPlugin(),
     new CopyWebpackPlugin([
-      { from: './src/static', to: './' },
+      { from: './src/static', to: './', globOptions: { ignore: ['**/.DS_Store'] } },
       { from: './src/monaco-faust/primitives.lib', to: './' },
       { from: './node_modules/faust2webaudio/dist/libfaust-wasm.*', to: './', flatten: true },
       { from: './node_modules/faust-ui/dist/faust-ui.*', to: './', flatten: true },


### PR DESCRIPTION
The workbox plugin throws some errors due to some `.DS_Store` files are copied to the `dist` directory. The PR adds an ignore rule to the specific file. Please check the `service-worker.js` after build and make sure there is no `.DS_Store` files.