### PR TITLE
bug fix: getTargets with mode & version check

### DIFF
--- a/src/version.d.ts
+++ b/src/version.d.ts
@@ -1,2 +1,2 @@
 declare const VERSION: string;
-export default VERSION;
+export = VERSION;

--- a/src/version.js
+++ b/src/version.js
@@ -1,8 +1,4 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { version } = require("../package.json");
 
-const timestamp = new Date().getTime();
-
-const VERSION = `${version}.${timestamp}`;
-
-module.exports = VERSION;
+module.exports = version;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -83,7 +83,7 @@ const config = {
       'window.jQuery': 'jquery'
     }),
     new WorkboxWebpackPlugin.GenerateSW({
-      cacheId: VERSION,
+      cacheId: VERSION + new Date().getTime(),
       cleanupOutdatedCaches: true,
       clientsClaim: true,
       skipWaiting: true,


### PR DESCRIPTION
- refactored getTargets using async function, call it using await
- fix bug with `mode` urlParam, emit change event when setting export plat/arch values.
- fix bug with versioning strategy and comparison. Now IDE will preserve previous params