### PR TITLE
take url params into account before compile the diagram of the file

### DIFF
--- a/src/FileManager.ts
+++ b/src/FileManager.ts
@@ -71,10 +71,17 @@ export class FileManager {
     mainFileChangeHandler?: (index: number, mainCode: string) => any = () => undefined;
 
     constructor(options: TOptions) {
-        Object.assign(this, options);
+        this.container = options.container;
+        this.fs = options.fs;
+        this.path = options.path;
+        this.$mainFile = options.$mainFile;
         this.getChildren();
         this.getFiles();
         this.bind();
+        this.selectHandler = options.selectHandler;
+        this.saveHandler = options.saveHandler;
+        this.deleteHandler = options.deleteHandler;
+        this.mainFileChangeHandler = options.mainFileChangeHandler;
         this.select(this._fileList[options.$mainFile]);
     }
     getChildren() {


### PR DESCRIPTION
There was a bug that URL Params were taken into account after files initialized (might be a bug from when we added amstram mode). This bug causes `realtime_compile` flag from URL not working properly. The PR fixes the problem by reorder some function calls in the FileManager. 