### PR TITLE
Enables support for webaudio channel counts > 2

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1692,6 +1692,7 @@ const initAudioCtx = async (audioEnv: FaustEditorAudioEnv, deviceId?: string) =>
             audioEnv.destination = audioEnv.audioCtx.destination;
         }
         */
+        audioEnv.destination.channelCount = audioEnv.destination.maxChannelCount;
         audioEnv.destination.channelInterpretation = "discrete";
     }
     return audioEnv;


### PR DESCRIPTION
Simple fix that allows the Faust IDE to output channel counts > 2 (stereo). This is related to [Issue #45](https://github.com/grame-cncm/faustide/issues/45) that I opened.

I really want to dev in quad!

Thanks.