### PR TITLE
Use the Location header if it is available

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -922,9 +922,11 @@ $(async () => {
                 $.ajax({
                     method: "GET",
                     url: `${path}/precompile`
-                }).done((result) => {
+                }).done((result, status, jqXHR) => {
                     if (result === "DONE") {
-                        const href = `${path}/${plat === "android" ? "binary.apk" : "binary.zip"}`;
+                        // faustservice MAY return Location : https://github.com/grame-cncm/faustservice/pull/10
+                        const location = jqXHR.getResponseHeader("Location")
+                        const href = location ? `${server}/${location}` : `${path}/${plat === "android" ? "binary.apk" : "binary.zip"}`;
                         $("#a-export-download").attr({ href });
                         $("#export-download").show();
                         if (download === true) {
@@ -933,7 +935,7 @@ $(async () => {
                         $("#qr-code").show();
                         QRCode.toCanvas(
                             $<HTMLCanvasElement>("#qr-code")[0],
-                            `${path}/${plat === "android" ? "binary.apk" : "binary.zip"}`
+                            href
                         );
                         return;
                     }
@@ -1541,9 +1543,11 @@ $(async () => {
                     $.ajax({
                         method: "GET",
                         url: `${path}/precompile`
-                    }).done((result) => {
+                    }).done((result, status, jqXHR) => {
                         if (result === "DONE") {
-                            const href = `${path}/binary.zip`;
+                            // faustservice MAY return Location : https://github.com/grame-cncm/faustservice/pull/10
+                            const location = jqXHR.getResponseHeader("Location")
+                            const href = location ? `${server}/${location}` : `${path}/binary.zip`;
                             ((e.originalEvent as MessageEvent).source as WindowProxy).postMessage({ type: "exported", href }, "*");
                         }
                     }).fail((jqXHR, textStatus) => {


### PR DESCRIPTION
[Faust service PR 10](https://github.com/grame-cncm/faustservice/pull/10) implements a scheme whereby the location of a generated artifact is returned in the Location header.

This allows us, in the IDE, to be independent of the artifact naming implemented by the faust service. This PR exploits that feature, while still retaining the hard-coded `binary.zip` artifact name for when the Location header is not present.

**Note**: This PR does not _depend_ on the `faustservice` PR. However, the functionality it implements will not be _exploited_ until the `faustservice` PR is merged.