### PR TITLE
Fix spikes in oscilloscopes rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7775,9 +7775,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "version": "2.79.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
+      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -51,6 +51,7 @@ export class Scope {
         const l = d.length;
         ctx.strokeStyle = "#FFFFFF";
         ctx.lineWidth = 2;
+        ctx.lineJoin = "round";
         ctx.beginPath();
         // Fastest way to get min and max to have: 1. max abs value for y scaling, 2. mean value for zero-crossing
         let min = d[0];

--- a/src/StaticScope.ts
+++ b/src/StaticScope.ts
@@ -166,6 +166,7 @@ export class StaticScope {
         const gridX = (w - left) / ($1 - $0 - 1);
         const step = Math.max(1, Math.round(1 / gridX)); // horizontal draw step for optimization
         ctx.lineWidth = 2;
+        ctx.lineJoin = "round";
         for (let i = 0; i < t.length; i++) {
             ctx.beginPath();
             ctx.strokeStyle = `hsl(${i * 60}, 100%, 85%)`;
@@ -262,6 +263,7 @@ export class StaticScope {
         const gridX = (w - left) / ($1 - $0 - 1);
         const step = Math.max(1, Math.round(1 / gridX));
         ctx.lineWidth = 2;
+        ctx.lineJoin = "round";
         for (let i = 0; i < t.length; i++) {
             ctx.beginPath();
             ctx.strokeStyle = t.length === 1 ? "white" : `hsl(${i * 60}, 100%, 85%)`;


### PR DESCRIPTION
Due to line drawing rendering issue in canvas, it produces weird spikes in oscilloscopes. Fixed with context.lineJoin = "round". 